### PR TITLE
Fix readonly variable crash in non-tty environments

### DIFF
--- a/src/lib/_Z_Utils.zsh
+++ b/src/lib/_Z_Utils.zsh
@@ -1446,8 +1446,12 @@ function z_Setup_Environment() {
     
     # Set up terminal capabilities if not already set
     function setup_Terminal_Capabilities() {
-        # Only initialize if they aren't already defined
-        if [[ -z "$Term_Reset" ]]; then
+        # Only initialize if they aren't already declared.
+        # Check variable existence, not emptiness: in non-tty environments,
+        # Term_Reset is set to empty string at line ~302 but is still readonly.
+        # Using -z would see "empty" and try to re-set it, crashing with
+        # "read-only variable".
+        if ! typeset -p Term_Reset >/dev/null 2>&1; then
             # Initialize terminal capabilities
             typeset -g Term_Reset="$(tput sgr0 2>/dev/null || echo '')"
             typeset -g Term_Bold="$(tput bold 2>/dev/null || echo '')"


### PR DESCRIPTION
## Summary

- `setup_Terminal_Capabilities()` crashes with "read-only variable: Term_Reset" in non-tty environments (SSH without TTY, CI, piped execution)
- Line 302 sets `Term_Reset` as readonly via `typeset -r -g`. In non-tty contexts, `tput sgr0` fails and the value is empty but still readonly
- Line 1450 checks emptiness (`-z`), sees empty, tries to re-set it -- crashes because the variable is readonly
- Fix: check variable existence (`typeset -p`) instead of emptiness (`-z`). A readonly empty variable is still declared

## Reproduction

```sh
ssh host 'source /path/to/_Z_Utils.zsh'
# Output: setup_Terminal_Capabilities:4: read-only variable: Term_Reset
```

## Test plan

- [ ] Verify in non-tty environment (SSH without TTY)
- [ ] Verify no regression in TTY environment
- [ ] Verify setup_git_inception_repo.sh works over SSH